### PR TITLE
Support Laravel DB connection table prefixes for models

### DIFF
--- a/src/api/TotalCircleController.php
+++ b/src/api/TotalCircleController.php
@@ -64,7 +64,7 @@ class TotalCircleController extends Controller
             } else {
                 $query = $model::selectRaw('SUM('.$calculation.') counted'.$seriesSql);
             }
-
+            
             if(is_numeric($advanceFilterSelected)){
                 $query->where($xAxisColumn, '>=', Carbon::now()->subDays($advanceFilterSelected));
             }
@@ -80,7 +80,7 @@ class TotalCircleController extends Controller
             else if($dataForLast != '*') {
                 $query->where($xAxisColumn, '>=', Carbon::now()->firstOfMonth()->subMonth($dataForLast-1));
             }
-
+            
             if(isset(json_decode($request->options, true)['queryFilter'])){
                 $queryFilter = json_decode($request->options, true)['queryFilter'];
                 foreach($queryFilter as $qF){

--- a/src/api/TotalCircleController.php
+++ b/src/api/TotalCircleController.php
@@ -64,7 +64,7 @@ class TotalCircleController extends Controller
             } else {
                 $query = $model::selectRaw('SUM('.$calculation.') counted'.$seriesSql);
             }
-            
+                
             if(is_numeric($advanceFilterSelected)){
                 $query->where($xAxisColumn, '>=', Carbon::now()->subDays($advanceFilterSelected));
             }

--- a/src/api/TotalCircleController.php
+++ b/src/api/TotalCircleController.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
 class TotalCircleController extends Controller

--- a/src/api/TotalRecordsController.php
+++ b/src/api/TotalRecordsController.php
@@ -141,7 +141,7 @@ class TotalRecordsController extends Controller
                 $query->groupBy('catorder', 'cat')
                     ->orderBy('catorder', 'asc');
             }
-
+            
             if(isset(json_decode($request->options, true)['queryFilter'])){
                 $queryFilter = json_decode($request->options, true)['queryFilter'];
                 foreach($queryFilter as $qF){
@@ -208,7 +208,7 @@ class TotalRecordsController extends Controller
             ]
         ]);
     }
-
+    
     private function counted($dataSet, $bgColor = "#111", $type = "bar")
     {
         $yAxis = [

--- a/src/api/TotalRecordsController.php
+++ b/src/api/TotalRecordsController.php
@@ -70,7 +70,7 @@ class TotalRecordsController extends Controller
                 } else {
                     $query = $model::selectRaw('DATE('.$xAxisColumn.') AS cat, DATE('.$xAxisColumn.') AS catorder, sum('.$calculation.') counted'.$seriesSql);
                 }
-
+                
                 if(is_numeric($advanceFilterSelected)){
                     $query->where($xAxisColumn, '>=', Carbon::now()->subDays($advanceFilterSelected));
                 }
@@ -96,7 +96,7 @@ class TotalRecordsController extends Controller
                 } else {
                     $query = $model::selectRaw('YEARWEEK('.$xAxisColumn.', '.$startWeek.') AS cat, YEARWEEK('.$xAxisColumn.', '.$startWeek.') AS catorder, sum('.$calculation.') counted'.$seriesSql);
                 }
-
+                
                 if(is_numeric($advanceFilterSelected)){
                     $query->where($xAxisColumn, '>=', Carbon::now()->subDays($advanceFilterSelected));
                 }
@@ -122,7 +122,7 @@ class TotalRecordsController extends Controller
                 } else {
                     $query = $model::selectRaw('DATE_FORMAT('.$xAxisColumn.', "%b %Y") AS cat, DATE_FORMAT('.$xAxisColumn.', "%Y-%m") AS catorder, sum('.$calculation.') counted'.$seriesSql);
                 }
-
+                
                 if(is_numeric($advanceFilterSelected)){
                     $query->where($xAxisColumn, '>=', Carbon::now()->subDays($advanceFilterSelected));
                 }

--- a/src/api/TotalRecordsController.php
+++ b/src/api/TotalRecordsController.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
 class TotalRecordsController extends Controller


### PR DESCRIPTION
Fixes #56. Adds the DB connection's prefix (empty string if none is set) to the X-axis table name. Prefixes are defined in the database connection array in `app/database.php`.