### PR TITLE
add queryFilters operators like (IN, NOT IN, BETWEEN, NOT BETWEEN)

### DIFF
--- a/src/api/TotalCircleController.php
+++ b/src/api/TotalCircleController.php
@@ -86,7 +86,7 @@ class TotalCircleController extends Controller
             if(isset(json_decode($request->options, true)['queryFilter'])){
                 $queryFilter = json_decode($request->options, true)['queryFilter'];
                 foreach($queryFilter as $qF){
-                    if(isset($qF['value'])){
+                    if(isset($qF['value']) && !is_array($qF['value'])){
                         if(isset($qF['operator'])){
                             $query->where($qF['key'], $qF['operator'], $qF['value']);
                         } else {
@@ -97,6 +97,14 @@ class TotalCircleController extends Controller
                             $query->whereNull($qF['key']);
                         } else if($qF['operator']=='IS NOT NULL'){
                             $query->whereNotNull($qF['key']);
+                        } else if($qF['operator']=='IN'){
+                            $query->whereIn($qF['key'], $qF['value']);
+                        } else if($qF['operator']=='NOT IN'){
+                            $query->whereIn($qF['key'], $qF['value']);
+                        } else if($qF['operator']=='BETWEEN') {
+                            $query->whereBetween($qF['key'], $qF['value']);
+                        } else if($qF['operator']=='NOT BETWEEN') {
+                            $query->whereNotBetween($qF['key'], $qF['value']);
                         }
                     }
                 }

--- a/src/api/TotalRecordsController.php
+++ b/src/api/TotalRecordsController.php
@@ -194,7 +194,7 @@ class TotalRecordsController extends Controller
             if(isset(json_decode($request->options, true)['queryFilter'])){
                 $queryFilter = json_decode($request->options, true)['queryFilter'];
                 foreach($queryFilter as $qF){
-                    if(isset($qF['value'])){
+                    if(isset($qF['value']) && !is_array($qF['value'])){
                         if(isset($qF['operator'])){
                             $query->where($qF['key'], $qF['operator'], $qF['value']);
                         } else {
@@ -205,6 +205,14 @@ class TotalRecordsController extends Controller
                             $query->whereNull($qF['key']);
                         } else if($qF['operator']=='IS NOT NULL'){
                             $query->whereNotNull($qF['key']);
+                        } else if($qF['operator']=='IN'){
+                            $query->whereIn($qF['key'], $qF['value']);
+                        } else if($qF['operator']=='NOT IN'){
+                            $query->whereIn($qF['key'], $qF['value']);
+                        } else if($qF['operator']=='BETWEEN') {
+                            $query->whereBetween($qF['key'], $qF['value']);
+                        } else if($qF['operator']=='NOT BETWEEN') {
+                            $query->whereNotBetween($qF['key'], $qF['value']);
                         }
                     }
                 }

--- a/src/api/TotalRecordsController.php
+++ b/src/api/TotalRecordsController.php
@@ -23,6 +23,7 @@ class TotalRecordsController extends Controller
             $request->merge(['model' => urldecode($request->input('model'))]);
         }
         $showTotal = isset($request->options) ? json_decode($request->options, true)['showTotal'] ?? true : true;
+        $totalLabel = isset($request->options) ? json_decode($request->options, true)['totalLabel'] ?? 'Total' : 'Total';
         $chartType = $request->type ?? 'bar';
         $advanceFilterSelected = isset($request->options) ? json_decode($request->options, true)['advanceFilterSelected'] ?? false : false;
         $dataForLast = isset($request->options) ? json_decode($request->options, true)['latestData'] ?? 3 : 3;
@@ -249,10 +250,10 @@ class TotalRecordsController extends Controller
                     $countKey++;
                 }
                 if($showTotal == true){
-                    $yAxis[$countKey] = $this->counted($dataSet, $defaultColor[$countKey], 'line');
+                    $yAxis[$countKey] = $this->counted($dataSet, $defaultColor[$countKey], 'line', $totalLabel);
                 }
             } else {
-                $yAxis[0] = $this->counted($dataSet, $defaultColor[0], $chartType);
+                $yAxis[0] = $this->counted($dataSet, $defaultColor[0], $chartType, $totalLabel);
             }
             if ($request->input('expires')) {
                 Cache::put($cacheKey, $dataSet, Carbon::parse($request->input('expires')));
@@ -266,11 +267,11 @@ class TotalRecordsController extends Controller
         ]);
     }
     
-    private function counted($dataSet, $bgColor = "#111", $type = "bar")
+    private function counted($dataSet, $bgColor = "#111", $type = "bar", $label = "Total")
     {
         $yAxis = [
             'type'  => $type,
-            'label' => 'Total',
+            'label' => $label,
             'data' => collect($dataSet)->map(function ($item, $key) {
                 return $item->only(['counted'])['counted'];
             })


### PR DESCRIPTION
You can use now new Operators like (IN, NOT IN, BETWEEN, NOT BETWEEN)

**BETWEEN**
`$queryFilterOption[] = [
                            'key' => 'votes',
                            'operator' => "BETWEEN",
                            'value' => [10, 20] //accept only two elements
                        ];`

**NOT BETWEEN**
`$queryFilterOption[] = [
                            'key' => 'votes',
                            'operator' => "NOT BETWEEN",
                            'value' => [1, 5] //accept only two elements
                        ];`


**IN**
`$queryFilterOption[] = [
                            'key' => 'book_id',
                            'operator' => "IN",
                            'value' => [1, 2, 20, 30]
                        ];`


**NOT IN**
`$queryFilterOption[] = [
                            'key' => 'user_id',
                            'operator' => "NOT IN",
                            'value' => [1, 2]
                        ];`