### PR TITLE
fix HttpExceptionInterface compatibility

### DIFF
--- a/src/api/ThrowError.php
+++ b/src/api/ThrowError.php
@@ -2,12 +2,12 @@
 
 namespace Coroowicaksono\ChartJsIntegration\Api;
 
-use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;  
 
 class ThrowError extends \Exception implements HttpExceptionInterface 
 {
     
-    public function getStatusCode()
+    public function getStatusCode(): int
    {
        return 500;
    }
@@ -17,7 +17,7 @@ class ThrowError extends \Exception implements HttpExceptionInterface
     *
     * @return array Response headers
     */
-   public function getHeaders()
+   public function getHeaders(): array
    {
        return [];
    }

--- a/src/api/ThrowError.php
+++ b/src/api/ThrowError.php
@@ -2,9 +2,9 @@
 
 namespace Coroowicaksono\ChartJsIntegration\Api;
 
-use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;  
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
-class ThrowError extends \Exception implements HttpExceptionInterface 
+class ThrowError extends \Exception implements HttpExceptionInterface
 {
     
     public function getStatusCode(): int


### PR DESCRIPTION
On Laravel 9 with PHP 8,  a compatibility issue with `HttpExceptionInterface` interface error occurs.
this is fixed by declaring return type for getStatusCode() and getHeaders().

Below are the errors thrown

1) Declaration of Coroowicaksono\ChartJsIntegration\Api\ThrowError::getStatusCode() must be compatible with Symfony\Component\HttpKernel\Exception\HttpExceptionInterface::getStatusCode()

2) Return type declaration must be compatible with HttpExceptionInterface->getHeaders() : array