### PR TITLE
Remove expression usage for Laravel 10 compatibility

### DIFF
--- a/src/api/TotalCircleController.php
+++ b/src/api/TotalCircleController.php
@@ -30,7 +30,7 @@ class TotalCircleController extends Controller
         $model = $request->input('model');
         $modelInstance = new $model;
         $tableName = $modelInstance->getConnection()->getTablePrefix() . $modelInstance->getTable();
-        $xAxisColumn = $request->input('col_xaxis') ?? DB::raw($tableName.'.created_at');
+        $xAxisColumn = $request->input('col_xaxis') ?? $tableName.'.created_at';
         $cacheKey = hash('md4', $model . (int)(bool)$request->input('expires'));
         $dataSet = Cache::get($cacheKey);
         if (!$dataSet) {

--- a/src/api/TotalRecordsController.php
+++ b/src/api/TotalRecordsController.php
@@ -39,7 +39,7 @@ class TotalRecordsController extends Controller
         $modelInstance = new $model;
         $connectionName = $modelInstance->getConnection()->getDriverName();
         $tableName = $modelInstance->getConnection()->getTablePrefix() . $modelInstance->getTable();
-        $xAxisColumn = $request->input('col_xaxis') ?? DB::raw($tableName.'.created_at');
+        $xAxisColumn = $request->input('col_xaxis') ?? $tableName.'.created_at';
         $cacheKey = hash('md4', $model . (int)(bool)$request->input('expires'));
         $dataSet = Cache::get($cacheKey);
         if (!$dataSet) {


### PR DESCRIPTION
Fixes #151

I have removed the `DB::raw` usage for setting the `$xAxisColumn` as it seems completely unnecessary to do this.

### Cause
**From the Laravel 10 upgrade guide:**
https://laravel.com/docs/10.x/upgrade#database-expressions
> Database "expressions" (typically generated via `DB::raw`) have been rewritten in Laravel 10.x to offer additional functionality in the future. Notably, the grammar's raw string value must now be retrieved via the expression's `getValue(Grammar $grammar)` method. Casting an expression to a string using `(string)` is no longer supported.
>
> **Typically, this does not affect end-user applications;** however, if your application is manually casting database expressions to strings using `(string)` or invoking the `__toString` method on the expression directly, you should update your code to invoke the `getValue` method instead:
> ```php
> use Illuminate\Support\Facades\DB;
>
> $expression = DB::raw('select 1');
> 
> $string = $expression->getValue(DB::connection()->getQueryGrammar());
> ```